### PR TITLE
Bump compatibility for TB 128

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,7 +4,7 @@
     "gecko": {
       "id": "birthdaycalendar@rsjtdrjgfuzkfg.com",
       "strict_min_version": "102.0",
-      "strict_max_version": "115.*"
+      "strict_max_version": "128.*"
     }
   },
   "name": "__MSG_extensionName__",


### PR DESCRIPTION
This commit updates the manifest to declare explicit support for Thunderbird 128, as tesets with recent betas did not indicate a need for any additional changes.